### PR TITLE
index.d.ts: fix header types

### DIFF
--- a/dist-js/index.d.ts
+++ b/dist-js/index.d.ts
@@ -1,5 +1,5 @@
 type ProgressHandler = (progress: number, total: number) => void;
-declare function upload(url: string, filePath: string, progressHandler?: ProgressHandler, headers?: Map<string, string>): Promise<void>;
-declare function download(url: string, filePath: string, progressHandler?: ProgressHandler, headers?: Map<string, string>): Promise<void>;
+declare function upload(url: string, filePath: string, progressHandler?: ProgressHandler, headers?: { [key: string]: string }): Promise<void>;
+declare function download(url: string, filePath: string, progressHandler?: ProgressHandler, headers?: { [key: string]: string }): Promise<void>;
 export default upload;
 export { download, upload };


### PR DESCRIPTION
From the example that's given in the README, the functions should accept a `{ [key: string]: string }` instead of a `Map<string, string>`.

I don't know if this is intended, but when I tried to pass a map to the function the headers didn't work, but with this they do.